### PR TITLE
include the free brands library

### DIFF
--- a/Icon.js
+++ b/Icon.js
@@ -20,7 +20,7 @@ const Icon = ( { name, size, color, type, containerStyle, iconStyle, onPress } )
   const path = iconData[4];
   const viewBox = [ 0, 0, iconData[0], iconData[1] ].join( " " );
 
-  const iconContent (
+  const iconContent = (
     <View style={containerStyle}>
       <Svg
         height={size}

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ This will allow you to download the pro solid, regular and light font packages f
 * Install the FontAwesome Pro packages ( you will not be able to install them without the previous step )
 
 ```
-npm install --save @fortawesome/fontawesome-pro-light @fortawesome/fontawesome-pro-regular @fortawesome/fontawesome-pro-solid
+npm install --save @fortawesome/fontawesome-free-brands @fortawesome/fontawesome-pro-light @fortawesome/fontawesome-pro-regular @fortawesome/fontawesome-pro-solid
 
 or
 
-yarn add @fortawesome/fontawesome-pro-light @fortawesome/fontawesome-pro-regular @fortawesome/fontawesome-pro-solid
+yarn add @fortawesome/fontawesome-free-brands @fortawesome/fontawesome-pro-light @fortawesome/fontawesome-pro-regular @fortawesome/fontawesome-pro-solid
 
 ```
 
@@ -78,7 +78,8 @@ import Icon from "react-native-fontawesome-pro";
   prefixType = {
     regular: "far",
     solid: "fas",
-    light: "fal"
+    light: "fal",
+    brands: "fab"
   };
 ```
 The icon `name` prop can be found in fontawesome.com/icons

--- a/config.js
+++ b/config.js
@@ -1,5 +1,6 @@
 import fontawesome from "@fortawesome/fontawesome";
 
+import brands from '@fortawesome/fontawesome-free-brands'
 import proLight from "@fortawesome/fontawesome-pro-light";
 import proRegular from "@fortawesome/fontawesome-pro-regular";
 import proSolid from "@fortawesome/fontawesome-pro-solid";
@@ -9,12 +10,13 @@ export const configureFontAwesomePro = ( prefixType = "regular" ) => {
     familyPrefix: prefixTypes[prefixType]
   };
 
-  fontawesome.library.add( proLight, proRegular, proSolid );
+  fontawesome.library.add( brands, proLight, proRegular, proSolid );
 }
 
 
 export const prefixTypes = {
   regular: "far",
   light: "fal",
-  solid: "fas"
+  solid: "fas",
+  brands: "fab"
 };

--- a/config.js
+++ b/config.js
@@ -1,6 +1,6 @@
 import fontawesome from "@fortawesome/fontawesome";
 
-import brands from '@fortawesome/fontawesome-free-brands'
+import brands from '@fortawesome/fontawesome-free-brands';
 import proLight from "@fortawesome/fontawesome-pro-light";
 import proRegular from "@fortawesome/fontawesome-pro-regular";
 import proSolid from "@fortawesome/fontawesome-pro-solid";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fontawesome-pro",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fontawesome-pro",
-  "version": "1.0.13",
+  "version": "1.0.12",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "react-native-svg": ">=5.3.0",
     "@fortawesome/fontawesome-pro-light": "*",
     "@fortawesome/fontawesome-pro-regular": "*",
-    "@fortawesome/fontawesome-pro-solid": "*"
+    "@fortawesome/fontawesome-pro-solid": "*",
+    "@fortawesome/fontawesome-free-brands": "*"
   },
   "jest": {
     "preset": "react-native"


### PR DESCRIPTION
In order to use icons like facebook, google, etc. we need the free brands library.
Correct me if I'm wrong but I think that webpack only actually includes imports that are being used (tree shaking).
So if a user doesn't include any brand icons, apps won't get any larger in terms of file size.