### PR TITLE
Support icons inline inside Text components.

### DIFF
--- a/Icon.js
+++ b/Icon.js
@@ -7,7 +7,7 @@ import { prefixTypes } from "./config";
 
 const DEFAULT_ICON = "question-circle";
 
-const Icon = ( { name, size, color, type, containerStyle, iconStyle, onPress } ) => {
+const Icon = ( { name, size, color, type, iconStyle, onPress } ) => {
 
   const prefix = prefixTypes[type];
   let icon = fontawesome.findIconDefinition( { prefix, iconName: name } );
@@ -21,22 +21,20 @@ const Icon = ( { name, size, color, type, containerStyle, iconStyle, onPress } )
   const viewBox = [ 0, 0, iconData[0], iconData[1] ].join( " " );
 
   const iconContent = (
-    <View style={containerStyle}>
-      <Svg
-        height={size}
-        version="1.1"
-        viewBox={viewBox}
-        width={size}
-        x="0"
-        y="0"
-        style={iconStyle}
-      >
-        <Path
-          d={path}
-          fill={color}
-        />
-      </Svg>
-    </View>
+    <Svg
+      height={size}
+      version="1.1"
+      viewBox={viewBox}
+      width={size}
+      x="0"
+      y="0"
+      style={iconStyle}
+    >
+      <Path
+        d={path}
+        fill={color}
+      />
+    </Svg>
   );
 
   if ( onPress ) {
@@ -59,10 +57,6 @@ Icon.propTypes = {
   iconStyle: PropTypes.oneOfType( [
     PropTypes.object,
     PropTypes.number
-  ] ),
-  containerStyle: PropTypes.oneOfType( [
-    PropTypes.object,
-    PropTypes.number
   ] )
 };
 
@@ -71,7 +65,6 @@ Icon.defaultProps = {
   size: 20,
   color: "black",
   type: "regular",
-  containerStyle: {},
   iconStyle: {},
   onPress: null
 };

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ If a valid name is not provided `question-circle` will show up instead.
 | size      | number      |   20                        |
 | type | prefixType as a string see definition above      |    "regular" |
 | iconStyle | style object      |    {} |
-| containerStyle | style object      |    {} |
 | onPress | function      |    null |
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fontawesome-pro",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest"


### PR DESCRIPTION
## Problem
View components are not allowed inside Text components.

## Solution
Removing this wrapping View container makes the Icon component
adaptable to more use cases. A container View can be manually added if/when usage requires.

## Version Bump
Because this change can break layouts of existing usage, the version got a minor bump.