### PR TITLE
Make container View optional. Allows icons inline inside Text.

### DIFF
--- a/Icon.js
+++ b/Icon.js
@@ -20,24 +20,30 @@ const Icon = ( { name, size, color, type, containerStyle, iconStyle, onPress } )
   const path = iconData[4];
   const viewBox = [ 0, 0, iconData[0], iconData[1] ].join( " " );
 
-  const iconContent = (
-    <View style={containerStyle}>
-      <Svg
-        height={size}
-        version="1.1"
-        viewBox={viewBox}
-        width={size}
-        x="0"
-        y="0"
-        style={iconStyle}
-      >
-        <Path
-          d={path}
-          fill={color}
-        />
-      </Svg>
-    </View>
+  let iconContent = (
+    <Svg
+      height={size}
+      version="1.1"
+      viewBox={viewBox}
+      width={size}
+      x="0"
+      y="0"
+      style={iconStyle}
+    >
+      <Path
+        d={path}
+        fill={color}
+      />
+    </Svg>
   );
+
+  if ( containerStyle ) {
+    iconContent = (
+      <View style={containerStyle}>
+        {iconContent}
+      </View>
+    );
+  }
 
   if ( onPress ) {
     return (
@@ -71,8 +77,8 @@ Icon.defaultProps = {
   size: 20,
   color: "black",
   type: "regular",
-  containerStyle: {},
-  iconStyle: {},
+  containerStyle: undefined,
+  iconStyle: undefined,
   onPress: null
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fontawesome-pro",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest"


### PR DESCRIPTION
## Problem
View components are not allowed inside Text components.

## Solution
Make the wrapping View container optional based upon existence of `containerStyle` prop. This makes the Icon component adaptable to more use cases.

## Installation
Add the following to your `package.json` file and then run `npm install`:
```
"react-native-fontawesome-pro": "beausmith/react-native-fontawesome-pro#optional-container-view",
```