### PR TITLE
Make container View optional. Allows icons inline inside Text.

### DIFF
--- a/Icon.js
+++ b/Icon.js
@@ -21,27 +21,29 @@ const Icon = ( { name, size, color, type, containerStyle, iconStyle, onPress } )
   const viewBox = [ 0, 0, iconData[0], iconData[1] ].join( " " );
 
   const iconContent = (
-    <View style={containerStyle}>
-      <Svg
-        height={size}
-        version="1.1"
-        viewBox={viewBox}
-        width={size}
-        x="0"
-        y="0"
-        style={iconStyle}
-      >
-        <Path
-          d={path}
-          fill={color}
-        />
-      </Svg>
-    </View>
+    <Svg
+      height={size}
+      version="1.1"
+      viewBox={viewBox}
+      width={size}
+      x="0"
+      y="0"
+      style={iconStyle}
+    >
+      <Path
+        d={path}
+        fill={color}
+      />
+    </Svg>
   );
 
-  if ( onPress ) {
+  if ( onPress || containerStyle ) {
     return (
-      <TouchableOpacity onPress={onPress}>
+      <TouchableOpacity
+        onPress={onPress}
+        disabled={!onPress}
+        style={containerStyle}
+      >
         {iconContent}
       </TouchableOpacity>
     );
@@ -70,10 +72,7 @@ Icon.defaultProps = {
   name: "",
   size: 20,
   color: "black",
-  type: "regular",
-  containerStyle: {},
-  iconStyle: {},
-  onPress: null
+  type: "regular"
 };
 
 export default Icon;

--- a/README.md
+++ b/README.md
@@ -1,104 +1,89 @@
 # react-native-fontawesome-pro
 Easily use your FontAwesome Pro icons in React-Native
 
-# Requirements
+# Install Prerequisites
 
-* Create a `.npmrc` file in the root of your project and the line below.
-Replace `TOKEN` with your FontAwesome Pro token
+1. Create a `.npmrc` file in the root of your project and the line below. Replace `YOUR-TOKEN-HERE` with your FontAwesome Pro token which you can find in your Font Awesome account <https://fontawesome.com/account/services>. More info: [Font Awesome docs: Using a Package Manager](https://fontawesome.com/how-to-use/on-the-web/setup/using-package-managers)
 
-```
-@fortawesome:registry=https://npm.fontawesome.com/
-//npm.fontawesome.com/:_authToken=<TOKEN>
-```
+        @fortawesome:registry=https://npm.fontawesome.com/
+        //npm.fontawesome.com/:_authToken=YOUR-TOKEN-HERE
 
-This will allow you to download the pro solid, regular and light font packages from the fontawesome pro repo.
+    This will allow you to download the pro solid, regular and light font packages from the fontawesome pro repo.
 
-* Install the FontAwesome Pro packages ( you will not be able to install them without the previous step )
+2. Install the FontAwesome Pro packages ( you will not be able to install them without the previous step )
 
-```
-npm install --save @fortawesome/fontawesome-free-brands @fortawesome/fontawesome-pro-light @fortawesome/fontawesome-pro-regular @fortawesome/fontawesome-pro-solid
+        npm install --save @fortawesome/fontawesome-free-brands @fortawesome/fontawesome-pro-light @fortawesome/fontawesome-pro-regular @fortawesome/fontawesome-pro-solid
 
-or
+    or
 
-yarn add @fortawesome/fontawesome-free-brands @fortawesome/fontawesome-pro-light @fortawesome/fontawesome-pro-regular @fortawesome/fontawesome-pro-solid
+        yarn add @fortawesome/fontawesome-free-brands @fortawesome/fontawesome-pro-light @fortawesome/fontawesome-pro-regular @fortawesome/fontawesome-pro-solid
 
-```
+3. Install `react-native-svg`
+
+        npm install --save react-native-svg
+
+    or
+
+        yarn add react-native-svg
+
+4. Link `react-native-svg`
 
 
-* Install `react-native-svg`
+        react-native link
 
-```
-npm install --save react-native-svg
+    …or if you only want to link the single library:
 
-or
+        react-native link react-native-svg
 
-yarn add react-native-svg
-```
+    **Note:** Rebuilding the app for any simulator/emulator is required after running `react-native link`.
 
-* Link `react-native-svg`
-
-```
-react-native link react-native-svg
-```
 
 # Installation
 
-`npm install react-native-fontawesome-pro --save`
+
+    npm install react-native-fontawesome-pro --save
 
 or
 
-`yarn add react-native-fontawesome-pro`
+    yarn add react-native-fontawesome-pro
 
 The postinstall script will then automatically install the pro packages for you.
 
+
 # Usage
 
-In your main app.js file
-```
-import { configureFontAwesomePro } from "react-native-fontawesome-pro";
+Configure FontAwesomePro in your main `app.js` file. Optionally set the default font from "regular" to "solid" or "light":
 
-/* NOTE: Optional you can pass a prefixType into configureFontAwesomePro to change the default from "regular" to "solid" or "light" */
+    import { configureFontAwesomePro } from "react-native-fontawesome-pro";
 
-configureFontAwesomePro();
-// configureFontAwesomePro("solid");
-// configureFontAwesomePro("light");
-```
+    configureFontAwesomePro();
+    // configureFontAwesomePro("solid");
+    // configureFontAwesomePro("light");
 
-In your components
-```
-import Icon from "react-native-fontawesome-pro";
+Add icons to a component:
 
-<View style={styles.container}>
-  <Icon name="chevron-right" color="red" type="regular" onPress={() => alert("do something")} />
-  <Icon name="chevron-right" color="blue" type="solid" size={24}/>
-  <Icon name="chevron-right" color="green" type="light" size={24} />
-</View>
-```
+    import Icon from "react-native-fontawesome-pro";
+
+    <View>
+      <Icon name="chevron-right" color="red" type="regular" onPress={() => alert("do something")} />
+      <Icon name="chevron-right" color="blue" type="solid" size={24}/>
+      <Icon name="chevron-right" color="green" type="light" size={10} />
+    </View>
 
 # Props
-```
-  prefixType = {
-    regular: "far",
-    solid: "fas",
-    light: "fal",
-    brands: "fab"
-  };
-```
-The icon `name` prop can be found in fontawesome.com/icons
-If a valid name is not provided `question-circle` will show up instead.
 
-| Props         | type          | default  |
-| ------------- |:-------------:| --------:|
-| name          | string        | ""                      |
-| color      | hexdecimal or string | "black"             |
-| size      | number      |   20                        |
-| type | prefixType as a string see definition above      |    "regular" |
-| iconStyle | style object      |    {} |
-| containerStyle | style object      |    {} |
-| onPress | function      |    null |
+Values for the Icon `name` prop can be found on [fontawesome.com/icons](https://fontawesome.com/icons).
 
+| prop | type | default value |
+| :- | :- | :- |
+| `name` | string | "" (If a valid `name` value is not provided, Font Awesome defaults to "question-circle") |
+| `color` | string, html color keyword or hexdecimal | "black" |
+| `size` | int | 20 |
+| `type` | string, one of the available Font Awesome prefix types: "regular", "solid", "light", or "brands" | "regular" |
+| `iconStyle` | style object | undefined |
+| `containerStyle` | style object | undefined |
+| `onPress` | function | undefined |
 
+###  PR's are welcome `¯\_(ツ)_/¯`
 
-
-###  PR's are welcome ¯\_(ツ)_/¯
 <a href="https://www.buymeacoffee.com/KDUHSQq" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/purple_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fontawesome-pro",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest"


### PR DESCRIPTION
## Problem
View components are not allowed inside Text components.

## Solution
Make the wrapping TouchableOpacity container optional based upon existence of `onPress` or `containerStyle` props. This makes the Icon component flexible in more use cases because the wrapping container is optional.

View the rendered README here: https://github.com/beausmith/react-native-fontawesome-pro/tree/conditional-view-container

#### Installation before this PR is merged to master…
Add the following to your `package.json` file and then run `npm install`:
```
"react-native-fontawesome-pro": "beausmith/react-native-fontawesome-pro#conditional-view-container",
```