### PR TITLE
Update Icon.js Prop validators

### DIFF
--- a/Icon.js
+++ b/Icon.js
@@ -61,11 +61,11 @@ Icon.propTypes = {
   type: PropTypes.oneOf( Object.keys( prefixTypes ) ),
   iconStyle: PropTypes.oneOfType( [
     PropTypes.object,
-    PropTypes.number
+    PropTypes.array
   ] ),
   containerStyle: PropTypes.oneOfType( [
     PropTypes.object,
-    PropTypes.number
+    PropTypes.array
   ] ),
   activeOpacity: PropTypes.number
 };

--- a/Icon.js
+++ b/Icon.js
@@ -75,8 +75,7 @@ Icon.defaultProps = {
   size: 20,
   color: "black",
   type: "regular",
-  activeOpacity: 0.2,
-  type: "regular"
+  activeOpacity: 0.2
 };
 
 export default Icon;


### PR DESCRIPTION
PropTypes validators for Icon and Container are marked as numbers when they only accept Object and Array.