### PR TITLE
Added ability to use Duotone icons.

### DIFF
--- a/Icon.js
+++ b/Icon.js
@@ -17,7 +17,6 @@ const Icon = ( { name, size, color, type, containerStyle, iconStyle, onPress, ac
   }
 
   const iconData = icon.icon;
-  const path = iconData[4];
   const viewBox = [ 0, 0, iconData[0], iconData[1] ].join( " " );
 
   const iconContent = (
@@ -30,10 +29,16 @@ const Icon = ( { name, size, color, type, containerStyle, iconStyle, onPress, ac
       y="0"
       style={iconStyle}
     >
-      <Path
-        d={path}
-        fill={color}
-      />
+       {Array.isArray(iconData[4]) ? (
+        <Fragment>
+          <Path d={iconData[4][0]} fill={color} opacity={0.4} />
+          <Path d={iconData[4][1]} fill={color} />
+        </Fragment>
+      ) : (
+        <Fragment>
+          <Path d={iconData[4]} fill={color} />
+        </Fragment>
+      )}
     </Svg>
   );
 

--- a/config.js
+++ b/config.js
@@ -3,12 +3,14 @@ import { fal } from "@fortawesome/pro-light-svg-icons";
 import { far } from "@fortawesome/pro-regular-svg-icons";
 import { fas } from "@fortawesome/pro-solid-svg-icons";
 import { fab } from '@fortawesome/free-brands-svg-icons';
+import { fad } from '@fortawesome/pro-duotone-svg-icons';
 
 export const prefixTypes = {
   regular: "far",
   light: "fal",
   solid: "fas",
-  brands: "fab"
+  brands: "fab",
+  duotone: "fad,"
 };
 
 export const configureFontAwesomePro = ( prefixType = "regular" ) => {
@@ -16,5 +18,5 @@ export const configureFontAwesomePro = ( prefixType = "regular" ) => {
     familyPrefix: prefixTypes[prefixType]
   };
 
-  library.add( fab, fal, far, fas );
+  library.add( fab, fal, far, fas, fad );
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ export interface IconProps extends ViewProps {
   name?: string;
   size?: number;
   color?: string;
-  type?: "regular" | "light" | "solid" | "brands";
+  type?: "regular" | "light" | "solid" | "brands" | "duotone";
   containerStyle?: ViewStyle;
   iconStyle?: ViewStyle;
   onPress?: () => void;


### PR DESCRIPTION
Duotone icons use two layers for the icon, with the second layer having a 40% opacity.  I added in "duotone" import, config, and changed the <svg> path results to check first if it is an array.  If it is an array, it prints the first and second layers of the icon.

_"By default the secondary layer is set to 40% opacity."_
[FontAwesome Blog Article Referencing 40% opacity](https://blog.fontawesome.com/introducing-duotone/)

This should close Issue #30 