### PR TITLE
Stop using `defaultProps`

### DIFF
--- a/Icon.js
+++ b/Icon.js
@@ -1,13 +1,22 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { View, TouchableOpacity } from "react-native"
+import { TouchableOpacity } from "react-native"
 import { Svg, Path } from "react-native-svg";
 import { findIconDefinition } from "@fortawesome/fontawesome-svg-core";
 import { prefixTypes } from "./config";
 
 const DEFAULT_ICON = "question-circle";
 
-const Icon = ( { name, size, color, type, containerStyle, iconStyle, onPress, activeOpacity } ) => {
+const Icon = ({
+	name = '',
+	size = 20,
+	color = 'black',
+	type = 'regular',
+	activeOpacity = 0.2,
+	containerStyle,
+	iconStyle,
+	onPress
+}) => {
 
   const prefix = prefixTypes[type];
   let icon = findIconDefinition( { prefix, iconName: name } );
@@ -68,14 +77,6 @@ Icon.propTypes = {
     PropTypes.array
   ] ),
   activeOpacity: PropTypes.number
-};
-
-Icon.defaultProps = {
-  name: "",
-  size: 20,
-  color: "black",
-  type: "regular",
-  activeOpacity: 0.2
 };
 
 export default Icon;


### PR DESCRIPTION
I get console warning on expo app (SDK 51), react 18.2.0 about the support for defaultProps will be removed from function components in a future major release.

Fount out there's movement, starting in newer react version to deprecate `defaultProps` and eventually in the feature will be removed entirely!

The warning is bit annoying so here is a pull request to remove the usage of defaultProps.